### PR TITLE
support environment property on scores

### DIFF
--- a/lib/langfuse_sdk/ingestor.ex
+++ b/lib/langfuse_sdk/ingestor.ex
@@ -143,7 +143,8 @@ defmodule LangfuseSdk.Ingestor do
         "observationId" => score.observation_id,
         "comment" => score.comment,
         "dataType" => score.data_type,
-        "configId" => score.config_id
+        "configId" => score.config_id,
+        "environment" => score.environment
       }
     }
   end

--- a/lib/langfuse_sdk/tracing/score.ex
+++ b/lib/langfuse_sdk/tracing/score.ex
@@ -17,7 +17,8 @@ defmodule LangfuseSdk.Tracing.Score do
     :trace_id,
     :observation_id,
     :data_type,
-    :config_id
+    :config_id,
+    :environment
   ]
 
   def new(opts \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LangfuseSdk.MixProject do
   use Mix.Project
 
-  @version "0.0.5"
+  @version "0.0.6"
   @url "https://github.com/appcues/langfuse_sdk"
 
   def project do


### PR DESCRIPTION
This `environment` value is supported by Langfuse server already, but was missing on the SDK implementation we are using. This will allow us to properly show scores in the dashboard based on environment filters - matching how we handle all other tracing data.